### PR TITLE
fix: Evita erros quando a env não estiver presente

### DIFF
--- a/src/application/use_cases/pedido/pedido.use_case.ts
+++ b/src/application/use_cases/pedido/pedido.use_case.ts
@@ -51,7 +51,7 @@ export class PedidoUseCase implements IPedidoUseCase {
     const pedidoDTO = this.pedidoDTOFactory.criarPedidoDTO(result);
 
     const mercadoPagoIsEnabled =
-      this.configService.get<string>('ENABLE_MERCADOPAGO').toLowerCase() ===
+      this.configService.get<string>('ENABLE_MERCADOPAGO')?.toLowerCase() ===
       'true';
 
     if (mercadoPagoIsEnabled) {

--- a/src/infrastructure/sql/database/postgres.config.service.ts
+++ b/src/infrastructure/sql/database/postgres.config.service.ts
@@ -15,7 +15,7 @@ export class PostgresConfigService implements TypeOrmOptionsFactory {
       username: this.configService.get<string>('DB_USERNAME'),
       password: this.configService.get<string>('DB_PASSWORD'),
       database: this.configService.get<string>('DB_NAME'),
-      ssl: this.configService.get<string>('DB_SSL').toLowerCase() === 'true',
+      ssl: this.configService.get<string>('DB_SSL')?.toLowerCase() === 'true',
       entities: [__dirname + '/../../../**/*.model.{js,ts}'],
       synchronize: true,
     };


### PR DESCRIPTION
Pessoal, fiz uma melhoria bem pequena na hora de ler as vars de ambiente `DB_SSL` e `ENABLE_MERCADOPAGO`

Poderiam aprovar pra mim pfv?