### PR TITLE
fix: Corrige erro "Categoria informada não existe"

### DIFF
--- a/src/application/use_cases/produto/produto.use_case.spec.ts
+++ b/src/application/use_cases/produto/produto.use_case.spec.ts
@@ -153,9 +153,6 @@ describe('ProdutoUseCase', () => {
     ).rejects.toThrow(
       new ProdutoNaoLocalizadoErro('Produto informado não existe'),
     );
-    expect(produtoFactoryMock.criarEntidadeProduto).toHaveBeenCalledWith(
-      atualizaProdutoDTOMock,
-    );
     expect(produtoRepositoryMock.buscarProdutoPorId).toHaveBeenCalledWith(
       produtoId,
     );

--- a/src/application/use_cases/produto/produto.use_case.ts
+++ b/src/application/use_cases/produto/produto.use_case.ts
@@ -73,10 +73,10 @@ export class ProdutoUseCase implements IProdutoUseCase {
     produtoId: string,
     produto: AtualizaProdutoDTO,
   ): Promise<HTTPResponse<ProdutoDTO>> {
+    await this.validarProdutoPorId(produtoId);
+    
     const produtoEntity =
       await this.produtoFactory.criarEntidadeProduto(produto);
-
-    await this.validarProdutoPorId(produtoId);
 
     if (produtoEntity.nome) {
       await this.validarProdutoPorNome(produtoEntity.nome);


### PR DESCRIPTION
Pessoal, encontrei um pequeno problema na hora de editar produtos: Ao tentar editar um produto que não existe, dava erro "Categoria informada não existe" (print abaixo).

<img width="348" alt="image" src="https://github.com/Grupo-G03-4SOAT-FIAP/rms-bff/assets/5115895/efe7a881-6000-4b88-aa99-728632504621">

Fiz uma pequena correção e agora será exibida a mensagem certa: "Produto informado não existe" (print abaixo).

<img width="337" alt="image" src="https://github.com/Grupo-G03-4SOAT-FIAP/rms-bff/assets/5115895/d065580c-6c87-44a5-bdff-f28c6b0e636a">

Testes ok.
<img width="433" alt="image" src="https://github.com/Grupo-G03-4SOAT-FIAP/rms-bff/assets/5115895/0f60703a-75e0-4f9a-b1f9-53be31c5bbc2">
