### PR TITLE
fix: Corrige casting de string para enum

### DIFF
--- a/src/infrastructure/sql/factories/sql.dto.factory.ts
+++ b/src/infrastructure/sql/factories/sql.dto.factory.ts
@@ -58,7 +58,7 @@ export class SQLDTOFactory {
 
     return new PedidoEntity(
       itensPedido,
-      StatusPedido[pedido.statusPedido],
+      pedido.statusPedido as StatusPedido,
       pedido.numeroPedido,
       pedido.pago,
       clienteEntity,


### PR DESCRIPTION
Pessoal, notei que o campo `statusPedido` sumiu.
<img width="371" alt="image" src="https://github.com/Grupo-G03-4SOAT-FIAP/rms-bff/assets/5115895/b103f7f1-8106-46e8-b048-dbadf5cb913b">

Essa PR traz de volta.
<img width="319" alt="image" src="https://github.com/Grupo-G03-4SOAT-FIAP/rms-bff/assets/5115895/f6bb6445-f387-4657-a9de-c7c507fe2db5">

