### PR TITLE
[MELHORIA] - Verificar a forma com que o NEST trata os módulos da aplicação

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -4,62 +4,20 @@ import { HttpModule } from '@nestjs/axios';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { PostgresConfigService } from './infrastructure/sql/database/postgres.config.service';
 
-import { ProdutoModel } from './infrastructure/sql/models/produto.model';
-import { CategoriaModel } from './infrastructure/sql/models/categoria.model';
-import { PedidoModel } from './infrastructure/sql/models/pedido.model';
-import { ItemPedidoModel } from './infrastructure/sql/models/item_pedido.model';
-import { ClienteModel } from './infrastructure/sql/models/cliente.model';
 import { AppController } from './presentation/rest/v1/controllers/app/app.controller';
-import { ProdutoController } from './presentation/rest/v1/controllers/produto/produto.controller';
-import { CategoriaController } from './presentation/rest/v1/controllers/categoria/categoria.controller';
-import { ClienteController } from './presentation/rest/v1/controllers/cliente/cliente.controller';
-import { PedidoController } from './presentation/rest/v1/controllers/pedido/pedido.controller';
-
 import { AppUseCase } from './application/use_cases/app/app.use_case';
-import { ProdutoUseCase } from './application/use_cases/produto/produto.use_case';
-import { ProdutoRepository } from './infrastructure/sql/repositories/produto/produto.repository';
-import { ProdutoFactory } from './domain/produto/factories/produto.factory';
-import { ProdutoDTOFactory } from './domain/produto/factories/produto.dto.factory';
-import { CategoriaUseCase } from './application/use_cases/categoria/categoria.use_case';
-import { CategoriaRepository } from './infrastructure/sql/repositories/categoria/categoria.repository';
-import { ClienteUseCase } from './application/use_cases/cliente/cliente.use_case';
-import { ClienteRepository } from './infrastructure/sql/repositories/cliente/cliente.repository';
-import { ClienteDTOFactory } from './domain/cliente/factories/cliente.dto.factory';
-import { PedidoUseCase } from './application/use_cases/pedido/pedido.use_case';
-import { PedidoRepository } from './infrastructure/sql/repositories/pedido/pedido.repository';
-import { PedidoFactory } from './domain/pedido/factories/pedido.factory';
-import { PedidoDTOFactory } from './domain/pedido/factories/pedido.dto.factory';
-import { PedidoService } from './domain/pedido/services/pedido.service';
-
-import { IProdutoUseCase } from './domain/produto/interfaces/produto.use_case.port';
-import { IProdutoRepository } from './domain/produto/interfaces/produto.repository.port';
-import { IProdutoFactory } from './domain/produto/interfaces/produto.factory.port';
-import { IProdutoDTOFactory } from './domain/produto/interfaces/produto.dto.factory.port';
-import { ICategoriaUseCase } from './domain/categoria/interfaces/categoria.use_case.port';
-import { ICategoriaRepository } from './domain/categoria/interfaces/categoria.repository.port';
-import { ICategoriaDTOFactory } from './domain/categoria/interfaces/categoria.dto.factory.port';
-import { IClienteUseCase } from './domain/cliente/interfaces/cliente.use_case.port';
-import { CategoriaDTOFactory } from './domain/categoria/factories/categoria.dto.factory';
-import { IClienteRepository } from './domain/cliente/interfaces/cliente.repository.port';
-import { IClienteDTOFactory } from './domain/cliente/interfaces/cliente.dto.factory.port';
-import { IPedidoUseCase } from './domain/pedido/interfaces/pedido.use_case.port';
-import { IPedidoRepository } from './domain/pedido/interfaces/pedido.repository.port';
-import { IPedidoFactory } from './domain/pedido/interfaces/pedido.factory.port';
-import { IPedidoDTOFactory } from './domain/pedido/interfaces/pedido.dto.factory.port';
-import { IGatewayPagamentoService } from './domain/pedido/interfaces/gatewaypag.service.port';
-import { GatewayMercadoPagoService } from './infrastructure/services/gateway_pagamentos/gatewaypag.service';
-import { SQLDTOFactory } from './infrastructure/sql/factories/sql.dto.factory';
+import { CategoriaModule } from './modules/categoria.module';
+import { ClienteModule } from './modules/client.module';
+import { ProdutoModule } from './modules/produto.module';
+import { PedidoModule } from './modules/pedido.module';
 
 @Module({
   imports: [
     HttpModule,
-    TypeOrmModule.forFeature([
-      ProdutoModel,
-      CategoriaModel,
-      PedidoModel,
-      ItemPedidoModel,
-      ClienteModel,
-    ]),
+    CategoriaModule,
+    ClienteModule,
+    ProdutoModule,
+    PedidoModule,
     ConfigModule.forRoot({
       isGlobal: true,
     }),
@@ -68,90 +26,7 @@ import { SQLDTOFactory } from './infrastructure/sql/factories/sql.dto.factory';
       inject: [PostgresConfigService],
     }),
   ],
-  controllers: [
-    AppController,
-    ProdutoController,
-    CategoriaController,
-    ClienteController,
-    PedidoController,
-  ],
-  providers: [
-    AppUseCase,
-    ProdutoUseCase,
-    ProdutoRepository,
-    ProdutoFactory,
-    ProdutoDTOFactory,
-    CategoriaUseCase,
-    CategoriaRepository,
-    ClienteUseCase,
-    ClienteRepository,
-    ClienteDTOFactory,
-    PedidoUseCase,
-    PedidoRepository,
-    PedidoFactory,
-    PedidoDTOFactory,
-    PedidoService,
-    SQLDTOFactory,
-    {
-      provide: IProdutoUseCase,
-      useClass: ProdutoUseCase,
-    },
-    {
-      provide: IProdutoRepository,
-      useClass: ProdutoRepository,
-    },
-    {
-      provide: IProdutoFactory,
-      useClass: ProdutoFactory,
-    },
-    {
-      provide: IProdutoDTOFactory,
-      useClass: ProdutoDTOFactory,
-    },
-    {
-      provide: ICategoriaUseCase,
-      useClass: CategoriaUseCase,
-    },
-    {
-      provide: ICategoriaRepository,
-      useClass: CategoriaRepository,
-    },
-    {
-      provide: ICategoriaDTOFactory,
-      useClass: CategoriaDTOFactory,
-    },
-    {
-      provide: IClienteUseCase,
-      useClass: ClienteUseCase,
-    },
-    {
-      provide: IClienteRepository,
-      useClass: ClienteRepository,
-    },
-    {
-      provide: IClienteDTOFactory,
-      useClass: ClienteDTOFactory,
-    },
-    {
-      provide: IPedidoUseCase,
-      useClass: PedidoUseCase,
-    },
-    {
-      provide: IPedidoRepository,
-      useClass: PedidoRepository,
-    },
-    {
-      provide: IPedidoFactory,
-      useClass: PedidoFactory,
-    },
-    {
-      provide: IPedidoDTOFactory,
-      useClass: PedidoDTOFactory,
-    },
-    {
-      provide: IGatewayPagamentoService,
-      useClass: GatewayMercadoPagoService,
-    },
-  ],
+  controllers: [AppController],
+  providers: [AppUseCase],
 })
 export class AppModule {}

--- a/src/application/use_cases/produto/produto.use_case.ts
+++ b/src/application/use_cases/produto/produto.use_case.ts
@@ -79,7 +79,8 @@ export class ProdutoUseCase implements IProdutoUseCase {
     atualizaProdutoDTO: AtualizaProdutoDTO,
   ): Promise<HTTPResponse<ProdutoDTO>> {
     await this.validarProdutoPorId(idProduto);
-    await this.validarProdutoPorNome(atualizaProdutoDTO.nome);
+    if (atualizaProdutoDTO.nome)
+      await this.validarProdutoPorNome(atualizaProdutoDTO.nome);
     const produto =
       await this.produtoFactory.criarEntidadeProduto(atualizaProdutoDTO);
     const produtoEditado = await this.produtoRepository.editarProduto(

--- a/src/modules/categoria.module.ts
+++ b/src/modules/categoria.module.ts
@@ -1,0 +1,36 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { CategoriaModel } from '../infrastructure/sql/models/categoria.model';
+import { CategoriaController } from '../presentation/rest/v1/controllers/categoria/categoria.controller';
+import { CategoriaUseCase } from '../application/use_cases/categoria/categoria.use_case';
+import { ICategoriaUseCase } from '../domain/categoria/interfaces/categoria.use_case.port';
+import { CategoriaRepository } from '../infrastructure/sql/repositories/categoria/categoria.repository';
+import { ICategoriaRepository } from '../domain/categoria/interfaces/categoria.repository.port';
+import { ICategoriaDTOFactory } from '../domain/categoria/interfaces/categoria.dto.factory.port';
+import { CategoriaDTOFactory } from '../domain/categoria/factories/categoria.dto.factory';
+import { SQLDTOFactory } from '../infrastructure/sql/factories/sql.dto.factory';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([CategoriaModel])],
+  controllers: [CategoriaController],
+  providers: [
+    CategoriaUseCase,
+    {
+      provide: ICategoriaUseCase,
+      useClass: CategoriaUseCase,
+    },
+    CategoriaRepository,
+    {
+      provide: ICategoriaRepository,
+      useClass: CategoriaRepository,
+    },
+    CategoriaDTOFactory,
+    {
+      provide: ICategoriaDTOFactory,
+      useClass: CategoriaDTOFactory,
+    },
+    SQLDTOFactory,
+  ],
+  exports: [ICategoriaRepository, ICategoriaDTOFactory, ICategoriaUseCase],
+})
+export class CategoriaModule {}

--- a/src/modules/client.module.ts
+++ b/src/modules/client.module.ts
@@ -1,0 +1,36 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { ClienteUseCase } from '../application/use_cases/cliente/cliente.use_case';
+import { ClienteDTOFactory } from '../domain/cliente/factories/cliente.dto.factory';
+import { IClienteDTOFactory } from '../domain/cliente/interfaces/cliente.dto.factory.port';
+import { IClienteRepository } from '../domain/cliente/interfaces/cliente.repository.port';
+import { IClienteUseCase } from '../domain/cliente/interfaces/cliente.use_case.port';
+import { ClienteModel } from '../infrastructure/sql/models/cliente.model';
+import { ClienteRepository } from '../infrastructure/sql/repositories/cliente/cliente.repository';
+import { ClienteController } from '../presentation/rest/v1/controllers/cliente/cliente.controller';
+import { SQLDTOFactory } from '../infrastructure/sql/factories/sql.dto.factory';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([ClienteModel])],
+  controllers: [ClienteController],
+  providers: [
+    ClienteUseCase,
+    {
+      provide: IClienteUseCase,
+      useClass: ClienteUseCase,
+    },
+    ClienteRepository,
+    {
+      provide: IClienteRepository,
+      useClass: ClienteRepository,
+    },
+    ClienteDTOFactory,
+    {
+      provide: IClienteDTOFactory,
+      useClass: ClienteDTOFactory,
+    },
+    SQLDTOFactory,
+  ],
+  exports: [IClienteUseCase, IClienteRepository, IClienteDTOFactory],
+})
+export class ClienteModule {}

--- a/src/modules/pedido.module.ts
+++ b/src/modules/pedido.module.ts
@@ -1,0 +1,59 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { PedidoUseCase } from '../application/use_cases/pedido/pedido.use_case';
+import { PedidoDTOFactory } from '../domain/pedido/factories/pedido.dto.factory';
+import { PedidoFactory } from '../domain/pedido/factories/pedido.factory';
+import { IPedidoDTOFactory } from '../domain/pedido/interfaces/pedido.dto.factory.port';
+import { IPedidoFactory } from '../domain/pedido/interfaces/pedido.factory.port';
+import { IPedidoRepository } from '../domain/pedido/interfaces/pedido.repository.port';
+import { IPedidoUseCase } from '../domain/pedido/interfaces/pedido.use_case.port';
+import { PedidoModel } from '../infrastructure/sql/models/pedido.model';
+import { PedidoRepository } from '../infrastructure/sql/repositories/pedido/pedido.repository';
+import { PedidoController } from '../presentation/rest/v1/controllers/pedido/pedido.controller';
+import { IGatewayPagamentoService } from '../domain/pedido/interfaces/gatewaypag.service.port';
+import { GatewayMercadoPagoService } from '../infrastructure/services/gateway_pagamentos/gatewaypag.service';
+import { SQLDTOFactory } from '../infrastructure/sql/factories/sql.dto.factory';
+import { ItemPedidoModel } from '../infrastructure/sql/models/item_pedido.model';
+import { ProdutoModule } from './produto.module';
+import { ClienteModule } from './client.module';
+import { PedidoService } from '../domain/pedido/services/pedido.service';
+
+@Module({
+  imports: [
+    ProdutoModule,
+    ClienteModule,
+    TypeOrmModule.forFeature([PedidoModel, ItemPedidoModel]),
+  ],
+  controllers: [PedidoController],
+  providers: [
+    PedidoUseCase,
+    {
+      provide: IPedidoUseCase,
+      useClass: PedidoUseCase,
+    },
+    PedidoRepository,
+    {
+      provide: IPedidoRepository,
+      useClass: PedidoRepository,
+    },
+    PedidoDTOFactory,
+    {
+      provide: IPedidoDTOFactory,
+      useClass: PedidoDTOFactory,
+    },
+    PedidoFactory,
+    {
+      provide: IPedidoFactory,
+      useClass: PedidoFactory,
+    },
+    GatewayMercadoPagoService,
+    {
+      provide: IGatewayPagamentoService,
+      useClass: GatewayMercadoPagoService,
+    },
+    SQLDTOFactory,
+    PedidoService,
+  ],
+  exports: [],
+})
+export class PedidoModule {}

--- a/src/modules/produto.module.ts
+++ b/src/modules/produto.module.ts
@@ -1,0 +1,49 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { ProdutoUseCase } from '../application/use_cases/produto/produto.use_case';
+import { ProdutoDTOFactory } from '../domain/produto/factories/produto.dto.factory';
+import { IProdutoDTOFactory } from '../domain/produto/interfaces/produto.dto.factory.port';
+import { IProdutoRepository } from '../domain/produto/interfaces/produto.repository.port';
+import { IProdutoUseCase } from '../domain/produto/interfaces/produto.use_case.port';
+import { ProdutoModel } from '../infrastructure/sql/models/produto.model';
+import { ProdutoRepository } from '../infrastructure/sql/repositories/produto/produto.repository';
+import { ProdutoController } from '../presentation/rest/v1/controllers/produto/produto.controller';
+import { ProdutoFactory } from '../domain/produto/factories/produto.factory';
+import { IProdutoFactory } from '../domain/produto/interfaces/produto.factory.port';
+import { SQLDTOFactory } from '../infrastructure/sql/factories/sql.dto.factory';
+import { CategoriaModule } from './categoria.module';
+
+@Module({
+  imports: [CategoriaModule, TypeOrmModule.forFeature([ProdutoModel])],
+  controllers: [ProdutoController],
+  providers: [
+    ProdutoUseCase,
+    {
+      provide: IProdutoUseCase,
+      useClass: ProdutoUseCase,
+    },
+    ProdutoRepository,
+    {
+      provide: IProdutoRepository,
+      useClass: ProdutoRepository,
+    },
+    ProdutoDTOFactory,
+    {
+      provide: IProdutoDTOFactory,
+      useClass: ProdutoDTOFactory,
+    },
+    ProdutoFactory,
+    {
+      provide: IProdutoFactory,
+      useClass: ProdutoFactory,
+    },
+    SQLDTOFactory,
+  ],
+  exports: [
+    IProdutoUseCase,
+    IProdutoRepository,
+    IProdutoDTOFactory,
+    IProdutoFactory,
+  ],
+})
+export class ProdutoModule {}


### PR DESCRIPTION
Hoje estamos declarando todas as dependências dentro do app.module, sendo ele o único arquivo de módulo da aplicação. Se observarmos a documentação do NEST: https://docs.nestjs.com/modules podemos ver que o framework divide as features em módulos:

O objetivo aqui é analisar a possibilidade de criar um módulo para cada feature contendo suas dependências e assim importar cada um dos módulos no app.module. Com isso teremos um app.module menor e cada módulo terá sua independência.

A implementação basicamente foi criar um pasta modules dentro de src e criar um arquivo de module para cada feature.
![image](https://github.com/Grupo-G03-4SOAT-FIAP/rms-bff/assets/28732069/91b0e719-5220-4e68-9690-c51465f79258)

Cada module contém seus controlers e providers. Caso seja utilizado algum deles por outro module são exportamos permitindo sua utilização.

Após a atualização todos os testes unitários foram executados sem erros:
![image](https://github.com/Grupo-G03-4SOAT-FIAP/rms-bff/assets/28732069/ba97a606-6f2e-451a-9c4a-5cbbd6abb683)

Ao realizar testes via swagger notamos uma inconsistência ao tentar editar um produto. Estávamos validando o nome do produto para qualquer alteração, mesmo que não seja o nome do item. Com isso ao tentar atualizar qualquer parâmetro do produto retorna conflito com o nome do mesmo. Dado isso adicionamos um if para que o nome do produto só seja validado caso tenha sido enviado algum conteúdo pelo parâmetro nome.
 

