### PR TITLE
fix: Corrige tipo de dado da coluna valor_unitario

### DIFF
--- a/api.http
+++ b/api.http
@@ -77,7 +77,7 @@ Content-Type: application/json
 
 {
     "nome": "X-Tudo",
-    "valorUnitario": 12,
+    "valorUnitario": 29.9,
     "descricao": "Ingredientes: 1 hambúrguer, 50 g de bacon picados, 1 ovo, 2 fatias de presunto, 2 fatias de mussarela (cheddar), 1 folha de alface, 1 rodela de tomate, 1 pão de hambúrguer, 1 colher de maionese, Catchup a gosto (opcional)",
     "imagemUrl": "https://conteudo.imguol.com.br/c/entretenimento/17/2023/05/24/x-tudo-brasileiro-tem-variedade-de-ingredientes-de-acordo-com-preferencias-regionais-aqui-versao-com-carne-bovina-tomato-salsicha-presunto-bacon-e-queijo-no-pao-1684938396547_v2_1x1.jpg",
     "categoriaId": "9fbc614b-9b44-4d35-8ec7-36e55ba7f0f4"
@@ -89,7 +89,7 @@ Content-Type: application/json
 
 {
     "nome": "X-Salada",
-    "valorUnitario": 15,
+    "valorUnitario": 16,
     "descricao": "Ingredientes: 1 hambúrguer, 50 g de bacon picados, 1 ovo, 2 fatias de presunto, 2 fatias de mussarela (cheddar), 1 folha de alface, 1 rodela de tomate, 1 pão de hambúrguer, 1 colher de maionese, Catchup a gosto (opcional)",
     "imagemUrl": "https://anamariabraga.globo.com/wp-content/uploads/2016/11/x-salada-classico.jpg",
     "categoriaId": "9fbc614b-9b44-4d35-8ec7-36e55ba7f0f4"

--- a/docs/Postman/Tech Challenge Fase 1 G03 turma 4SOAT.postman_collection.json
+++ b/docs/Postman/Tech Challenge Fase 1 G03 turma 4SOAT.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "70004c7c-5ed4-4c5f-be46-5bdc82fe0a06",
+		"_postman_id": "d47002de-be94-4932-a7ca-14c92af180d8",
 		"name": "Tech Challenge Fase 1 G03 turma 4SOAT",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
 		"_exporter_id": "4241772"
@@ -340,7 +340,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\r\n    \"nome\": \"X-Tudo\",\r\n    \"valorUnitario\": 12,\r\n    \"descricao\": \"Ingredientes: 1 hambúrguer, 50 g de bacon picados, 1 ovo, 2 fatias de presunto, 2 fatias de mussarela (cheddar), 1 folha de alface, 1 rodela de tomate, 1 pão de hambúrguer, 1 colher de maionese, Catchup a gosto (opcional)\",\r\n    \"imagemUrl\": \"https://conteudo.imguol.com.br/c/entretenimento/17/2023/05/24/x-tudo-brasileiro-tem-variedade-de-ingredientes-de-acordo-com-preferencias-regionais-aqui-versao-com-carne-bovina-tomato-salsicha-presunto-bacon-e-queijo-no-pao-1684938396547_v2_1x1.jpg\",\r\n    \"categoriaId\": \"9fbc614b-9b44-4d35-8ec7-36e55ba7f0f4\" // Colocar o UUID da categoria aqui\r\n}",
+							"raw": "{\r\n    \"nome\": \"X-Tudo\",\r\n    \"valorUnitario\": 29.9,\r\n    \"descricao\": \"Ingredientes: 1 hambúrguer, 50 g de bacon picados, 1 ovo, 2 fatias de presunto, 2 fatias de mussarela (cheddar), 1 folha de alface, 1 rodela de tomate, 1 pão de hambúrguer, 1 colher de maionese, Catchup a gosto (opcional)\",\r\n    \"imagemUrl\": \"https://conteudo.imguol.com.br/c/entretenimento/17/2023/05/24/x-tudo-brasileiro-tem-variedade-de-ingredientes-de-acordo-com-preferencias-regionais-aqui-versao-com-carne-bovina-tomato-salsicha-presunto-bacon-e-queijo-no-pao-1684938396547_v2_1x1.jpg\",\r\n    \"categoriaId\": \"9fbc614b-9b44-4d35-8ec7-36e55ba7f0f4\" // Colocar o UUID da categoria aqui\r\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -368,7 +368,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\r\n    \"nome\": \"X-Salada\",\r\n    \"valorUnitario\": 15,\r\n    \"descricao\": \"Ingredientes: 1 hambúrguer, 50 g de bacon picados, 1 ovo, 2 fatias de presunto, 2 fatias de mussarela (cheddar), 1 folha de alface, 1 rodela de tomate, 1 pão de hambúrguer, 1 colher de maionese, Catchup a gosto (opcional)\",\r\n    \"imagemUrl\": \"https://anamariabraga.globo.com/wp-content/uploads/2016/11/x-salada-classico.jpg\",\r\n    \"categoriaId\": \"e5f99bae-0a90-4ca0-b6f8-ab9efb41e721\" // Colocar o UUID da categoria aqui\r\n}",
+							"raw": "{\r\n    \"nome\": \"X-Salada\",\r\n    \"valorUnitario\": 16,\r\n    \"descricao\": \"Ingredientes: 1 hambúrguer, 50 g de bacon picados, 1 ovo, 2 fatias de presunto, 2 fatias de mussarela (cheddar), 1 folha de alface, 1 rodela de tomate, 1 pão de hambúrguer, 1 colher de maionese, Catchup a gosto (opcional)\",\r\n    \"imagemUrl\": \"https://anamariabraga.globo.com/wp-content/uploads/2016/11/x-salada-classico.jpg\",\r\n    \"categoriaId\": \"e5f99bae-0a90-4ca0-b6f8-ab9efb41e721\" // Colocar o UUID da categoria aqui\r\n}",
 							"options": {
 								"raw": {
 									"language": "json"

--- a/src/infrastructure/sql/models/produto.model.ts
+++ b/src/infrastructure/sql/models/produto.model.ts
@@ -21,7 +21,7 @@ export class ProdutoModel {
   @Column({ name: 'descricao', length: 255, nullable: true })
   descricao: string;
 
-  @Column({ name: 'valor_unitario', nullable: false })
+  @Column({ type: "money", name: 'valor_unitario', nullable: false })
   valorUnitario: number;
 
   @Column({ name: 'imagem_url', length: 2048, nullable: false })


### PR DESCRIPTION
Correção no tipo de dado da coluna `valor_unitario` da tabela `produtos` de **integer** para **money**.

<img width="179" alt="image" src="https://github.com/Grupo-G03-4SOAT-FIAP/rms-bff/assets/5115895/cd2228f4-f35b-464b-968c-5dff6061b8f4">

<br>
<br>

Testes ok.
<img width="511" alt="image" src="https://github.com/Grupo-G03-4SOAT-FIAP/rms-bff/assets/5115895/dbf2ba66-bcb0-4492-807c-80b48f139a65">
