### PR TITLE
ci: Separa o Lint e o Sonar em 2 workflows

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,4 +1,4 @@
-name: Standard
+name: Lint
 
 on:
   push:
@@ -45,10 +45,3 @@ jobs:
         run: npm ci
       - name: Lint
         run: npm run lint
-      - name: Test
-        run: npm run test:cov
-      - name: Sonar Analysis
-        uses: SonarSource/sonarcloud-github-action@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,0 +1,28 @@
+name: SonarCloud
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, synchronize, reopened]
+jobs:
+  sonarcloud:
+    name: SonarCloud
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+      # O Step abaixo foi adicionado manualmente para enviar o resultado do test coverage para o SonarCloud.
+      # Mais informações em https://docs.sonarsource.com/sonarqube/9.8/analyzing-source-code/test-coverage/javascript-typescript-test-coverage/#add-coverage
+      - name: Install dependencies
+        run: npm install
+      # O Step abaixo foi adicionado manualmente para enviar o resultado do test coverage para o SonarCloud.
+      # Mais informações em https://docs.sonarsource.com/sonarqube/9.8/analyzing-source-code/test-coverage/javascript-typescript-test-coverage/#add-coverage
+      - name: Test and coverage
+        run: npx jest --coverage
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarcloud-github-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
Pessoal, boa noite

Ao assistir as aulas de GitHub Actions, achei melhor separar o workflow do SonarCloud do workflow do Lint.

Motivos:

1) Ambos não precisam ficar juntos dentro do mesmo arquivo yaml, já que cada uma tem uma função e objetivo diferente do outro;
2) Dessa forma é possível ativar/desativar cada um separadamente caso a gente queira;
3) Ao separar evitamos que erros em um workflow barre indevidamente a execução do outro;
4) O ideal é que cada arquivo yaml tenha uma única função e objetivo bem definido para facilitar a manutenção, assim como fazemos com as Classes na orientação a objetos.
5) Ao separar os workflows a execução fica mais rápida, pois o GitHub irá executar ambos em paralelo ao msm tempo, o que não acontece se deixamos tudo dentro de um único arquivo yaml;
6) Ao separar as coisas, fica mais fácil e mais claro determinar o que exatamente e onde deu problema quando tivermos algum alerta ao abrir PRs;
7) Ao separar os workflows podemos configurar a aprovação do Sonar como sendo obrigatória, mas não o Lint, ou vice-versa, se quisermos.

<img width="641" alt="image" src="https://github.com/Grupo-G03-4SOAT-FIAP/rms-bff/assets/5115895/4b8cddb3-838d-4a9e-8990-26035a304334">

Repare no print acima que o pass do Lint aparece separado do pass do Sonar, assim da para saber mais facilmente o que passou e o que não passou exatamente.

Podemos criar quantos arquivos yaml quisermos no GitHub. Todos serão executados da mesma forma.
 
 > Obs.: Notei que o Lint está executando duas vezes seguidas ao msm tempo: Sempre que é feito um push e sempre que é aberta uma PR. Mas essa correção fica para outra PR para não misturar os assuntos...
