### PR TITLE
adicionado service postgres no action

### DIFF
--- a/.github/workflows/standard.yaml
+++ b/.github/workflows/standard.yaml
@@ -23,7 +23,7 @@ on:
 jobs:
 
   ci:
-    name: CI - Build and Test
+    name: CI
     services:
       postgres:
         image: postgres:latest


### PR DESCRIPTION
Adicionado o service postgres no CI do action para que os teste de integração seja executados nesse banco ao inves do original, assim garantimos segurança e qualidade na base de dados do sistema.