### PR TITLE
Feature/79/cognito

### DIFF
--- a/src/application/use_cases/pedido/pedido.use_case.spec.ts
+++ b/src/application/use_cases/pedido/pedido.use_case.spec.ts
@@ -20,6 +20,12 @@ import {
   pedidoModelMock,
   pedidoRepositoryMock,
 } from 'src/mocks/pedido.mock';
+import {
+  clienteDTOMock,
+  clienteModelMock,
+  clienteRepositoryMock,
+} from 'src/mocks/cliente.mock';
+import { IClienteRepository } from 'src/domain/cliente/interfaces/cliente.repository.port';
 
 describe('PedidoUseCase', () => {
   let pedidoUseCase: PedidoUseCase;
@@ -32,6 +38,10 @@ describe('PedidoUseCase', () => {
         {
           provide: IPedidoRepository,
           useValue: pedidoRepositoryMock,
+        },
+        {
+          provide: IClienteRepository,
+          useValue: clienteRepositoryMock,
         },
         {
           provide: IPedidoFactory,
@@ -65,8 +75,15 @@ describe('PedidoUseCase', () => {
     pedidoRepositoryMock.criarPedido.mockReturnValue(pedidoModelMock);
     gatewayPagamentoServiceMock.criarPedido.mockReturnValue(null);
     pedidoDTOFactoryMock.criarPedidoDTO.mockReturnValue(pedidoDTOMock);
+    pedidoFactoryMock.criarEntidadeCliente.mockReturnValue(pedidoEntityMock);
+    clienteRepositoryMock.buscarClientePorCPF.mockReturnValue(clienteModelMock);
+    clienteRepositoryMock.criarCliente.mockReturnValue(clienteModelMock);
+    clienteRepositoryMock.editarCliente.mockReturnValue(clienteModelMock);
 
-    const result = await pedidoUseCase.criarPedido(criaPedidoDTOMock);
+    const result = await pedidoUseCase.criarPedido(
+      clienteDTOMock,
+      criaPedidoDTOMock,
+    );
 
     expect(pedidoFactoryMock.criarEntidadePedido).toHaveBeenCalledWith(
       criaPedidoDTOMock,

--- a/src/domain/pedido/entities/pedido.entity.spec.ts
+++ b/src/domain/pedido/entities/pedido.entity.spec.ts
@@ -11,6 +11,7 @@ describe('PedidoEntity', () => {
   let numeroPedido: string;
   let pago: boolean;
   let cliente: ClienteEntity;
+  let clientePedido: ClienteEntity;
   let id: string;
 
   beforeEach(() => {
@@ -20,6 +21,7 @@ describe('PedidoEntity', () => {
     numeroPedido = '05012024';
     pago = false;
     cliente = clienteEntityMock;
+    clientePedido = clienteEntityMock;
     id = '0a14aa4e-75e7-405f-8301-81f60646c93d';
   });
 
@@ -30,6 +32,7 @@ describe('PedidoEntity', () => {
       numeroPedido,
       pago,
       cliente,
+      clientePedido,
       id,
     );
 

--- a/src/domain/pedido/entities/pedido.entity.ts
+++ b/src/domain/pedido/entities/pedido.entity.ts
@@ -8,6 +8,7 @@ export class PedidoEntity {
   private _numeroPedido: string;
   private _pago: boolean;
   private _cliente?: ClienteEntity;
+  private _clientePedido?: ClienteEntity;
   private _id?: string;
   private _criadoEm?: string;
   private _atualizadoEm?: string;
@@ -18,6 +19,7 @@ export class PedidoEntity {
     numeroPedido: string,
     pago: boolean,
     cliente?: ClienteEntity,
+    clientePedido?: ClienteEntity,
     id?: string,
     criadoEm?: string,
     atualizadoEm?: string,
@@ -27,6 +29,7 @@ export class PedidoEntity {
     this.pago = pago;
     this.itensPedido = itensPedido;
     this.cliente = cliente;
+    this.clientePedido = clientePedido;
     this.statusPedido = statusPedido;
     this.criadoEm = criadoEm;
     this.atualizadoEm = atualizadoEm;
@@ -70,6 +73,14 @@ export class PedidoEntity {
 
   set cliente(cliente: ClienteEntity | undefined) {
     this._cliente = cliente;
+  }
+
+  get clientePedido(): ClienteEntity | undefined {
+    return this._clientePedido;
+  }
+
+  set clientePedido(clientePedido: ClienteEntity | undefined) {
+    this._clientePedido = clientePedido;
   }
 
   get id(): string | undefined {

--- a/src/domain/pedido/factories/pedido.factory.spec.ts
+++ b/src/domain/pedido/factories/pedido.factory.spec.ts
@@ -104,7 +104,7 @@ describe('PedidoFactory', () => {
       clienteEntityMock,
     );
 
-    const result = await pedidoFactory.criarEntidadeCliente(
+    const result = await pedidoFactory.criarEntidadeClienteDoCPF(
       criaPedidoDTOMock.cpfCliente,
     );
 
@@ -116,7 +116,7 @@ describe('PedidoFactory', () => {
     clienteRepositoryMock.buscarClientePorCPF.mockReturnValue(null);
 
     await expect(
-      pedidoFactory.criarEntidadeCliente(criaPedidoDTOMock.cpfCliente),
+      pedidoFactory.criarEntidadeClienteDoCPF(criaPedidoDTOMock.cpfCliente),
     ).rejects.toThrow(
       new ClienteNaoLocalizadoErro('Cliente informado não existe'),
     );

--- a/src/domain/pedido/factories/pedido.factory.ts
+++ b/src/domain/pedido/factories/pedido.factory.ts
@@ -11,6 +11,7 @@ import { ClienteNaoLocalizadoErro } from 'src/domain/cliente/exceptions/cliente.
 import { CriaPedidoDTO } from 'src/presentation/rest/v1/presenters/pedido/pedido.dto';
 import { PedidoEntity } from '../entities/pedido.entity';
 import { StatusPedido } from '../enums/pedido.enum';
+import { ClienteDTO } from 'src/presentation/rest/v1/presenters/cliente/cliente.dto';
 
 @Injectable()
 export class PedidoFactory implements IPedidoFactory {
@@ -21,6 +22,15 @@ export class PedidoFactory implements IPedidoFactory {
     @Inject(IProdutoRepository)
     private readonly produtoRepository: IProdutoRepository,
   ) {}
+
+  async criarEntidadeCliente(clienteDTO: ClienteDTO): Promise<ClienteEntity> {
+    return new ClienteEntity(
+      clienteDTO.nome,
+      clienteDTO.email,
+      clienteDTO.cpf,
+      clienteDTO.id,
+    );
+  }
 
   async criarItemPedido(
     itens: CriaItemPedidoDTO[],
@@ -43,7 +53,7 @@ export class PedidoFactory implements IPedidoFactory {
     return itensPedido;
   }
 
-  async criarEntidadeCliente(
+  async criarEntidadeClienteDoCPF(
     cpfCliente?: string,
   ): Promise<ClienteEntity | null> {
     const cliente =
@@ -60,7 +70,7 @@ export class PedidoFactory implements IPedidoFactory {
 
     let clienteEntity = null;
     if (pedido.cpfCliente) {
-      clienteEntity = await this.criarEntidadeCliente(pedido.cpfCliente);
+      clienteEntity = await this.criarEntidadeClienteDoCPF(pedido.cpfCliente);
 
       return new PedidoEntity(
         itensPedido,

--- a/src/domain/pedido/interfaces/pedido.factory.port.ts
+++ b/src/domain/pedido/interfaces/pedido.factory.port.ts
@@ -3,10 +3,12 @@ import { ItemPedidoEntity } from '../entities/item_pedido.entity';
 import { ClienteEntity } from 'src/domain/cliente/entities/cliente.entity';
 import { CriaPedidoDTO } from 'src/presentation/rest/v1/presenters/pedido/pedido.dto';
 import { PedidoEntity } from '../entities/pedido.entity';
+import { ClienteDTO } from 'src/presentation/rest/v1/presenters/cliente/cliente.dto';
 
 export interface IPedidoFactory {
   criarItemPedido(itens: CriaItemPedidoDTO[]): Promise<ItemPedidoEntity[]>;
-  criarEntidadeCliente(cpfCliente: string): Promise<ClienteEntity | null>;
+  criarEntidadeCliente(clienteDTO: ClienteDTO): Promise<ClienteEntity | null>;
+  criarEntidadeClienteDoCPF(cpfCliente: string): Promise<ClienteEntity | null>;
   criarEntidadePedido(pedido: CriaPedidoDTO): Promise<PedidoEntity>;
 }
 

--- a/src/domain/pedido/interfaces/pedido.use_case.port.ts
+++ b/src/domain/pedido/interfaces/pedido.use_case.port.ts
@@ -1,4 +1,5 @@
 import { HTTPResponse } from 'src/application/common/HTTPResponse';
+import { ClienteDTO } from 'src/presentation/rest/v1/presenters/cliente/cliente.dto';
 import { MensagemMercadoPagoDTO } from 'src/presentation/rest/v1/presenters/pedido/gatewaypag.dto';
 import {
   AtualizaPedidoDTO,
@@ -10,7 +11,10 @@ export interface IPedidoUseCase {
   listarPedidos(): Promise<PedidoDTO[] | []>;
   listarPedidosRecebido(): Promise<PedidoDTO[] | []>;
   buscarPedido(idPedido: string): Promise<PedidoDTO>;
-  criarPedido(criaPedidoDTO: CriaPedidoDTO): Promise<HTTPResponse<PedidoDTO>>;
+  criarPedido(
+    clienteDTO: ClienteDTO,
+    criaPedidoDTO: CriaPedidoDTO,
+  ): Promise<HTTPResponse<PedidoDTO>>;
   editarPedido(
     idPedido: string,
     atualizaPedidoDTO: AtualizaPedidoDTO,

--- a/src/infrastructure/sql/factories/sql.dto.factory.ts
+++ b/src/infrastructure/sql/factories/sql.dto.factory.ts
@@ -9,6 +9,7 @@ import { PedidoModel } from '../models/pedido.model';
 import { PedidoEntity } from 'src/domain/pedido/entities/pedido.entity';
 import { StatusPedido } from 'src/domain/pedido/enums/pedido.enum';
 import { ItemPedidoEntity } from 'src/domain/pedido/entities/item_pedido.entity';
+import { ClientePedidoModel } from '../models/cliente_pedido.model';
 
 @Injectable()
 export class SQLDTOFactory {
@@ -32,7 +33,7 @@ export class SQLDTOFactory {
     );
   }
 
-  criarClienteDTO(cliente: ClienteModel): ClienteEntity {
+  criarClienteDTOFromClienteModel(cliente: ClienteModel): ClienteEntity {
     if (!cliente) {
       return null;
     }
@@ -44,8 +45,25 @@ export class SQLDTOFactory {
     );
   }
 
+  criarClienteDTOFromClientePedidoModel(
+    clientePedido: ClientePedidoModel,
+  ): ClienteEntity {
+    if (!clientePedido) {
+      return null;
+    }
+    return new ClienteEntity(
+      clientePedido.nome,
+      clientePedido.email,
+      clientePedido.cpf,
+      clientePedido.id,
+    );
+  }
+
   criarPedidoDTO(pedido: PedidoModel): PedidoEntity {
-    const clienteEntity = this.criarClienteDTO(pedido.cliente);
+    const clienteEntity = this.criarClienteDTOFromClienteModel(pedido.cliente);
+    const clientePedidoEntity = this.criarClienteDTOFromClientePedidoModel(
+      pedido.clientePedido,
+    );
 
     const itensPedido = pedido.itensPedido.map((itemPedidoModel) => {
       const produtoEntity = this.criarProdutoDTO(itemPedidoModel.produto);
@@ -62,6 +80,7 @@ export class SQLDTOFactory {
       pedido.numeroPedido,
       pedido.pago,
       clienteEntity,
+      clientePedidoEntity,
       pedido.id,
       pedido.criadoEm,
       pedido.atualizadoEm,

--- a/src/infrastructure/sql/models/cliente_pedido.model.ts
+++ b/src/infrastructure/sql/models/cliente_pedido.model.ts
@@ -1,0 +1,27 @@
+import {
+  Column,
+  Entity,
+  JoinColumn,
+  OneToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import { PedidoModel } from './pedido.model';
+
+@Entity('cliente_pedido')
+export class ClientePedidoModel {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ name: 'nome', length: 100, nullable: false })
+  nome: string;
+
+  @Column({ name: 'email', length: 100, nullable: false })
+  email: string;
+
+  @Column({ name: 'cpf', length: 100, nullable: false })
+  cpf: string;
+
+  @OneToOne(() => PedidoModel, { nullable: false })
+  @JoinColumn({ name: 'id_pedido' })
+  pedido: PedidoModel;
+}

--- a/src/infrastructure/sql/models/pedido.model.ts
+++ b/src/infrastructure/sql/models/pedido.model.ts
@@ -5,11 +5,13 @@ import {
   JoinColumn,
   ManyToOne,
   OneToMany,
+  OneToOne,
   PrimaryGeneratedColumn,
   UpdateDateColumn,
 } from 'typeorm';
 import { ClienteModel } from './cliente.model';
 import { ItemPedidoModel } from './item_pedido.model';
+import { ClientePedidoModel } from './cliente_pedido.model';
 
 @Entity('pedidos')
 export class PedidoModel {
@@ -27,6 +29,10 @@ export class PedidoModel {
   @ManyToOne(() => ClienteModel, { nullable: true })
   @JoinColumn({ name: 'id_cliente' })
   cliente: ClienteModel | null;
+
+  @OneToOne(() => ClientePedidoModel, { nullable: true })
+  @JoinColumn({ name: 'id_cliente_pedido' })
+  clientePedido: ClientePedidoModel | null;
 
   @Column({ name: 'pago', nullable: false })
   pago: boolean;

--- a/src/infrastructure/sql/repositories/cliente/cliente.repository.spec.ts
+++ b/src/infrastructure/sql/repositories/cliente/cliente.repository.spec.ts
@@ -55,7 +55,9 @@ describe('ClienteRepository', () => {
     clienteTypeORMMock.save.mockResolvedValue(
       Promise.resolve(clienteModelMock),
     );
-    clienteSQLDTOFactoryMock.criarClienteDTO.mockReturnValue(clienteEntityMock);
+    clienteSQLDTOFactoryMock.criarClienteDTOFromClienteModel.mockReturnValue(
+      clienteEntityMock,
+    );
 
     const result = await clienteRepository.criarCliente(clienteEntityNotIdMock);
 
@@ -63,9 +65,9 @@ describe('ClienteRepository', () => {
       clienteEntityNotIdMock,
     );
     expect(clienteTypeORMMock.save).toHaveBeenCalledWith(clienteModelMock);
-    expect(clienteSQLDTOFactoryMock.criarClienteDTO).toHaveBeenCalledWith(
-      clienteModelMock,
-    );
+    expect(
+      clienteSQLDTOFactoryMock.criarClienteDTOFromClienteModel,
+    ).toHaveBeenCalledWith(clienteModelMock);
     expect(result).toStrictEqual(clienteEntityMock);
   });
 
@@ -78,16 +80,18 @@ describe('ClienteRepository', () => {
       raw: [{ clienteModelMock }],
       generatedMaps: [{}],
     });
-    clienteSQLDTOFactoryMock.criarClienteDTO.mockReturnValue(clienteEntityMock);
+    clienteSQLDTOFactoryMock.criarClienteDTOFromClienteModel.mockReturnValue(
+      clienteEntityMock,
+    );
 
     const result = await clienteRepository.criarCliente(clienteEntityNotIdMock);
 
     expect(clienteTypeORMMock.restore).toHaveBeenCalledWith({
       id: clienteModelMock.id,
     });
-    expect(clienteSQLDTOFactoryMock.criarClienteDTO).toHaveBeenCalledWith(
-      clienteModelMock,
-    );
+    expect(
+      clienteSQLDTOFactoryMock.criarClienteDTOFromClienteModel,
+    ).toHaveBeenCalledWith(clienteModelMock);
     expect(result).toStrictEqual(clienteEntityMock);
   });
 
@@ -96,7 +100,9 @@ describe('ClienteRepository', () => {
     clienteTypeORMMock.findOne.mockResolvedValue(
       Promise.resolve(clienteModelMock),
     );
-    clienteSQLDTOFactoryMock.criarClienteDTO.mockReturnValue(clienteEntityMock);
+    clienteSQLDTOFactoryMock.criarClienteDTOFromClienteModel.mockReturnValue(
+      clienteEntityMock,
+    );
 
     const result = await clienteRepository.editarCliente(
       clienteId,
@@ -113,9 +119,9 @@ describe('ClienteRepository', () => {
     expect(clienteTypeORMMock.findOne).toHaveBeenCalledWith({
       where: { id: clienteId },
     });
-    expect(clienteSQLDTOFactoryMock.criarClienteDTO).toHaveBeenCalledWith(
-      clienteModelMock,
-    );
+    expect(
+      clienteSQLDTOFactoryMock.criarClienteDTOFromClienteModel,
+    ).toHaveBeenCalledWith(clienteModelMock);
     expect(result).toStrictEqual(clienteEntityMock);
   });
 
@@ -138,16 +144,18 @@ describe('ClienteRepository', () => {
     clienteTypeORMMock.findOne.mockResolvedValue(
       Promise.resolve(clienteModelMock),
     );
-    clienteSQLDTOFactoryMock.criarClienteDTO.mockReturnValue(clienteEntityMock);
+    clienteSQLDTOFactoryMock.criarClienteDTOFromClienteModel.mockReturnValue(
+      clienteEntityMock,
+    );
 
     const result = await clienteRepository.buscarClientePorId(clienteId);
 
     expect(clienteTypeORMMock.findOne).toHaveBeenCalledWith({
       where: { id: clienteId },
     });
-    expect(clienteSQLDTOFactoryMock.criarClienteDTO).toHaveBeenCalledWith(
-      clienteModelMock,
-    );
+    expect(
+      clienteSQLDTOFactoryMock.criarClienteDTOFromClienteModel,
+    ).toHaveBeenCalledWith(clienteModelMock);
     expect(result).toStrictEqual(clienteEntityMock);
   });
 
@@ -166,16 +174,18 @@ describe('ClienteRepository', () => {
     clienteTypeORMMock.findOne.mockResolvedValue(
       Promise.resolve(clienteModelMock),
     );
-    clienteSQLDTOFactoryMock.criarClienteDTO.mockReturnValue(clienteEntityMock);
+    clienteSQLDTOFactoryMock.criarClienteDTOFromClienteModel.mockReturnValue(
+      clienteEntityMock,
+    );
 
     const result = await clienteRepository.buscarClientePorCPF(cpfCliente);
 
     expect(clienteTypeORMMock.findOne).toHaveBeenCalledWith({
       where: { cpf: cpfCliente },
     });
-    expect(clienteSQLDTOFactoryMock.criarClienteDTO).toHaveBeenCalledWith(
-      clienteModelMock,
-    );
+    expect(
+      clienteSQLDTOFactoryMock.criarClienteDTOFromClienteModel,
+    ).toHaveBeenCalledWith(clienteModelMock);
     expect(result).toStrictEqual(clienteEntityMock);
   });
 
@@ -194,16 +204,18 @@ describe('ClienteRepository', () => {
     clienteTypeORMMock.findOne.mockResolvedValue(
       Promise.resolve(clienteModelMock),
     );
-    clienteSQLDTOFactoryMock.criarClienteDTO.mockReturnValue(clienteEntityMock);
+    clienteSQLDTOFactoryMock.criarClienteDTOFromClienteModel.mockReturnValue(
+      clienteEntityMock,
+    );
 
     const result = await clienteRepository.buscarClientePorEmail(emailCliente);
 
     expect(clienteTypeORMMock.findOne).toHaveBeenCalledWith({
       where: { email: emailCliente },
     });
-    expect(clienteSQLDTOFactoryMock.criarClienteDTO).toHaveBeenCalledWith(
-      clienteModelMock,
-    );
+    expect(
+      clienteSQLDTOFactoryMock.criarClienteDTOFromClienteModel,
+    ).toHaveBeenCalledWith(clienteModelMock);
     expect(result).toStrictEqual(clienteEntityMock);
   });
 
@@ -232,14 +244,16 @@ describe('ClienteRepository', () => {
     clienteTypeORMMock.find.mockResolvedValue(
       Promise.resolve(listaClienteModel),
     );
-    clienteSQLDTOFactoryMock.criarClienteDTO.mockReturnValue(clienteEntityMock);
+    clienteSQLDTOFactoryMock.criarClienteDTOFromClienteModel.mockReturnValue(
+      clienteEntityMock,
+    );
 
     const result = await clienteRepository.listarClientes();
 
     expect(clienteTypeORMMock.find).toHaveBeenCalledWith({});
-    expect(clienteSQLDTOFactoryMock.criarClienteDTO).toHaveBeenCalledWith(
-      clienteModelMock,
-    );
+    expect(
+      clienteSQLDTOFactoryMock.criarClienteDTOFromClienteModel,
+    ).toHaveBeenCalledWith(clienteModelMock);
     expect(result).toStrictEqual(listaClienteEntity);
   });
 

--- a/src/infrastructure/sql/repositories/cliente/cliente.repository.ts
+++ b/src/infrastructure/sql/repositories/cliente/cliente.repository.ts
@@ -23,11 +23,13 @@ export class ClienteRepository implements IClienteRepository {
       this.clienteRepository.restore({
         id: clienteExistente.id,
       });
-      return this.sqlDTOFactory.criarClienteDTO(clienteExistente);
+      return this.sqlDTOFactory.criarClienteDTOFromClienteModel(
+        clienteExistente,
+      );
     } else {
       const clienteModel = this.clienteRepository.create(cliente);
       await this.clienteRepository.save(clienteModel);
-      return this.sqlDTOFactory.criarClienteDTO(clienteModel);
+      return this.sqlDTOFactory.criarClienteDTOFromClienteModel(clienteModel);
     }
   }
 
@@ -41,7 +43,9 @@ export class ClienteRepository implements IClienteRepository {
       where: { id: clienteId },
     });
     if (clienteModelAtualizado) {
-      return this.sqlDTOFactory.criarClienteDTO(clienteModelAtualizado);
+      return this.sqlDTOFactory.criarClienteDTOFromClienteModel(
+        clienteModelAtualizado,
+      );
     }
     return null;
   }
@@ -55,7 +59,7 @@ export class ClienteRepository implements IClienteRepository {
       where: { id: clienteId },
     });
     if (clienteModel) {
-      return this.sqlDTOFactory.criarClienteDTO(clienteModel);
+      return this.sqlDTOFactory.criarClienteDTOFromClienteModel(clienteModel);
     }
     return null;
   }
@@ -65,7 +69,7 @@ export class ClienteRepository implements IClienteRepository {
       where: { cpf: cpfCliente },
     });
     if (clienteModel) {
-      return this.sqlDTOFactory.criarClienteDTO(clienteModel);
+      return this.sqlDTOFactory.criarClienteDTOFromClienteModel(clienteModel);
     }
     return null;
   }
@@ -77,7 +81,7 @@ export class ClienteRepository implements IClienteRepository {
       where: { email: emailCliente },
     });
     if (clienteModel) {
-      return this.sqlDTOFactory.criarClienteDTO(clienteModel);
+      return this.sqlDTOFactory.criarClienteDTOFromClienteModel(clienteModel);
     }
     return null;
   }
@@ -85,7 +89,7 @@ export class ClienteRepository implements IClienteRepository {
   async listarClientes(): Promise<[] | ClienteEntity[]> {
     const listaClienteModel = await this.clienteRepository.find({});
     const clienteEntityList = listaClienteModel.map((cliente: ClienteModel) => {
-      return this.sqlDTOFactory.criarClienteDTO(cliente);
+      return this.sqlDTOFactory.criarClienteDTOFromClienteModel(cliente);
     });
 
     return clienteEntityList;

--- a/src/infrastructure/sql/repositories/pedido/pedido.repository.spec.ts
+++ b/src/infrastructure/sql/repositories/pedido/pedido.repository.spec.ts
@@ -13,10 +13,12 @@ import {
   pedidoEntityNotIdMock,
 } from 'src/mocks/pedido.mock';
 import {
+  clientePedidoTypeORMMock,
   itemPedidoModelMock,
   itemPedidoTypeORMMock,
 } from 'src/mocks/item_pedido.mock';
 import { SQLDTOFactory } from '../../factories/sql.dto.factory';
+import { ClientePedidoModel } from '../../models/cliente_pedido.model';
 
 describe('PedidoRepository', () => {
   let pedidoRepository: PedidoRepository;
@@ -36,6 +38,10 @@ describe('PedidoRepository', () => {
           useValue: itemPedidoTypeORMMock,
         },
         {
+          provide: getRepositoryToken(ClientePedidoModel),
+          useValue: clientePedidoTypeORMMock,
+        },
+        {
           provide: SQLDTOFactory,
           useValue: pedidoSQLDTOFactoryMock,
         },
@@ -46,6 +52,7 @@ describe('PedidoRepository', () => {
     pedidoId = '0a14aa4e-75e7-405f-8301-81f60646c93d';
     relations = [
       'cliente',
+      'clientePedido',
       'itensPedido',
       'itensPedido.produto',
       'itensPedido.produto.categoria',

--- a/src/infrastructure/sql/repositories/pedido/pedido.repository.ts
+++ b/src/infrastructure/sql/repositories/pedido/pedido.repository.ts
@@ -12,6 +12,7 @@ import { SQLDTOFactory } from '../../factories/sql.dto.factory';
 export class PedidoRepository implements IPedidoRepository {
   readonly relations = [
     'cliente',
+    'clientePedido',
     'itensPedido',
     'itensPedido.produto',
     'itensPedido.produto.categoria',

--- a/src/mocks/cliente.mock.ts
+++ b/src/mocks/cliente.mock.ts
@@ -56,6 +56,12 @@ clienteDTOMock.nome = clienteModelMock.nome;
 clienteDTOMock.email = clienteModelMock.email;
 clienteDTOMock.cpf = clienteModelMock.cpf;
 
+// Mock para simular o DTO com dados de cliente enviados para o usuario ao responder uma requisição
+export const clienteDTONotIdMock = new ClienteDTO();
+clienteDTONotIdMock.nome = clienteDTOMock.nome;
+clienteDTONotIdMock.email = clienteDTOMock.email;
+clienteDTONotIdMock.cpf = clienteDTOMock.cpf;
+
 // Mock jest das funções do typeORM interagindo com a tabela cliente
 export const clienteTypeORMMock: jest.Mocked<Repository<ClienteModel>> = {
   create: jest.fn(),
@@ -82,7 +88,8 @@ export const clienteRepositoryMock = {
 
 // Mock jest da função do factory sql dto de cliente
 export const clienteSQLDTOFactoryMock = {
-  criarClienteDTO: jest.fn(),
+  criarClienteDTOFromClienteModel: jest.fn(),
+  criarClienteDTOFromClientePedidoModel: jest.fn(),
 };
 
 // Mock jest das funções da factory que cria DTO cliente

--- a/src/mocks/item_pedido.mock.ts
+++ b/src/mocks/item_pedido.mock.ts
@@ -11,6 +11,7 @@ import {
   CriaItemPedidoDTO,
   ItemPedidoDTO,
 } from 'src/presentation/rest/v1/presenters/pedido/item_pedido.dto';
+import { ClientePedidoModel } from 'src/infrastructure/sql/models/cliente_pedido.model';
 
 // Mock para simular dados da tabela item pedido no banco de dados
 export const itemPedidoModelMock = new ItemPedidoModel();
@@ -51,4 +52,14 @@ export const itemPedidoTypeORMMock: jest.Mocked<Repository<ItemPedidoModel>> = {
   save: jest.fn(),
 } as Partial<jest.Mocked<Repository<ItemPedidoModel>>> as jest.Mocked<
   Repository<ItemPedidoModel>
+>;
+
+// Mock jest das funções do typeORM interagindo com a tabela cliente pedido
+export const clientePedidoTypeORMMock: jest.Mocked<
+  Repository<ClientePedidoModel>
+> = {
+  create: jest.fn(),
+  save: jest.fn(),
+} as Partial<jest.Mocked<Repository<ClientePedidoModel>>> as jest.Mocked<
+  Repository<ClientePedidoModel>
 >;

--- a/src/mocks/pedido.mock.ts
+++ b/src/mocks/pedido.mock.ts
@@ -42,6 +42,7 @@ export const pedidoEntityMock = new PedidoEntity(
   '05012024',
   false,
   clienteEntityMock,
+  clienteEntityMock,
   '0a14aa4e-75e7-405f-8301-81f60646c93d',
   '2024-01-25T00:05:04.941Z',
   '2024-01-25T00:05:04.941Z',
@@ -53,6 +54,7 @@ export const pedidoEntityNotDateMock = new PedidoEntity(
   StatusPedido.RECEBIDO,
   '05012024',
   false,
+  clienteEntityMock,
   clienteEntityMock,
   '0a14aa4e-75e7-405f-8301-81f60646c93d',
 );
@@ -126,7 +128,7 @@ export const pedidoTypeORMMock: jest.Mocked<Repository<PedidoModel>> = {
 export const configServiceMock = {
   get: jest.fn((key: string) => {
     if (key === 'ENABLE_AMZ_COGNITO_CIAM') {
-      return 'false';
+      return 'true';
     }
     if (key === 'ENABLE_MERCADOPAGO') {
       return 'false';

--- a/src/modules/pedido.module.ts
+++ b/src/modules/pedido.module.ts
@@ -18,12 +18,17 @@ import { ProdutoModule } from './produto.module';
 import { ClienteModule } from './client.module';
 import { PedidoService } from '../domain/pedido/services/pedido.service';
 import { AuthenticationGuard } from '@nestjs-cognito/auth';
+import { ClientePedidoModel } from 'src/infrastructure/sql/models/cliente_pedido.model';
 
 @Module({
   imports: [
     ProdutoModule,
     ClienteModule,
-    TypeOrmModule.forFeature([PedidoModel, ItemPedidoModel]),
+    TypeOrmModule.forFeature([
+      PedidoModel,
+      ItemPedidoModel,
+      ClientePedidoModel,
+    ]),
   ],
   controllers: [PedidoController],
   providers: [

--- a/src/presentation/rest/v1/controllers/pedido/pedido.controller.spec.ts
+++ b/src/presentation/rest/v1/controllers/pedido/pedido.controller.spec.ts
@@ -13,6 +13,7 @@ import {
 } from 'src/mocks/pedido.mock';
 import { CognitoTestingModule } from '@nestjs-cognito/testing';
 import { ConfigService } from '@nestjs/config';
+import { clienteDTOMock, clienteDTONotIdMock } from 'src/mocks/cliente.mock';
 
 describe('PedidoController', () => {
   let pedidoController: PedidoController;
@@ -56,9 +57,15 @@ describe('PedidoController', () => {
 
     pedidoUseCaseMock.criarPedido.mockReturnValue(HTTPResponse);
 
-    const result = await pedidoController.checkout(undefined, criaPedidoDTOMock);
+    const result = await pedidoController.checkout(
+      clienteDTOMock.cpf,
+      clienteDTOMock.nome,
+      clienteDTOMock.email,
+      criaPedidoDTOMock,
+    );
 
     expect(pedidoUseCaseMock.criarPedido).toHaveBeenCalledWith(
+      clienteDTONotIdMock,
       criaPedidoDTOMock,
     );
     expect(result).toStrictEqual(HTTPResponse);
@@ -70,9 +77,15 @@ describe('PedidoController', () => {
     );
 
     await expect(
-      pedidoController.checkout(undefined, criaPedidoDTOMock),
+      pedidoController.checkout(
+        clienteDTOMock.cpf,
+        clienteDTOMock.nome,
+        clienteDTOMock.email,
+        criaPedidoDTOMock,
+      ),
     ).rejects.toThrow(new NotFoundException('Cliente informado não existe'));
     expect(pedidoUseCaseMock.criarPedido).toHaveBeenCalledWith(
+      clienteDTONotIdMock,
       criaPedidoDTOMock,
     );
   });

--- a/src/presentation/rest/v1/controllers/pedido/pedido.controller.ts
+++ b/src/presentation/rest/v1/controllers/pedido/pedido.controller.ts
@@ -10,7 +10,6 @@ import {
   Post,
   Put,
   Query,
-  UseGuards,
 } from '@nestjs/common';
 import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { IPedidoUseCase } from 'src/domain/pedido/interfaces/pedido.use_case.port';
@@ -22,7 +21,7 @@ import {
 import { BadRequestError } from '../../helpers/swagger/status-codes/bad_requests.swagger';
 import { NotFoundError } from '../../helpers/swagger/status-codes/not_found.swagger';
 import { MensagemMercadoPagoDTO } from '../../presenters/pedido/gatewaypag.dto';
-import { AuthenticationGuard, CognitoUser } from '@nestjs-cognito/auth';
+import { CognitoUser } from '@nestjs-cognito/auth';
 import { ConfigService } from '@nestjs/config';
 
 @Controller('pedido')
@@ -52,7 +51,7 @@ export class PedidoController {
     description: 'Pedido informado não existe',
     type: NotFoundError,
   })
-  @UseGuards(AuthenticationGuard)
+  //@UseGuards(AuthenticationGuard)
   async checkout(
     @CognitoUser('username') username: string,
     @Body() pedido: CriaPedidoDTO,


### PR DESCRIPTION
Pessoal, bom dia

Conforme havia prometido, fiz aqui rapidinho uma implementação de histórico de dados de Clientes e também atualização automática da tabela `clientes` conforme os usuário forem criando pedidos.

1) Front-end do totem cadastra um novo cliente através da API do Cognito em https://cognito-idp.us-east-1.amazonaws.com
2) Front-end do totem faz Login do novo cliente usando a API do Cognito em https://cognito-idp.us-east-1.amazonaws.com, sem informar nenhuma senha, passando apenas o CPF
3) Front-end do totem recebe um Token de `Authorization` da API do Cognito, válido por 3600min
4) Front-end do totem faz um POST /pedido pra nossa API do RMS
5) A lib @nestjs-cognito/auth que instalei trata de, por baixo dos panos, ler o `Authorization` na request e buscar o Nome, o CPF e E-mail do cliente logado no Cognito automaticamente pra gente.
6) A lib @nestjs-cognito/auth injeta os campos `nome`, `email` e `cpf` na Controller de pedidos em POST /pedido pra gente
7) Checamos se um cliente com o CPF em questão já existe na nossa tabela de clientes
8) Cadastramos o cliente na nossa tabela `clientes`, no nosso banco de dados, de acordo com os dados fornecidos pelo Cognito que a lib @nestjs-cognito/auth injetou na Controller pra gente
9) Se um cliente com o CPF em questão já existir na nossa tabela de clientes, fazemos UPDATE e atualizamos os campos `nome`, `email` dele (isso pode acontecer caso o cliente tenha alterado os dados dele no Cognito por exemplo)
10) Gravamos o pedido no nosso banco de dados, e junto gravamos uma "foto" dos dados do cliente no momento em que o pedido foi criado, numa tabela que chamei de `cliente_pedido` que funciona como um histórico

Testes ok.
<img width="556" alt="image" src="https://github.com/Grupo-G03-4SOAT-FIAP/rms-bff/assets/5115895/ded9eb66-785c-4bcc-aea7-ba328eb390d5">
