### PR TITLE
fix: Corrige tipo do campo valorUnitario no bd

### DIFF
--- a/src/infrastructure/sql/models/ColumnNumericTransformer.ts
+++ b/src/infrastructure/sql/models/ColumnNumericTransformer.ts
@@ -1,0 +1,8 @@
+export class ColumnNumericTransformer {
+    to(data: number): number {
+        return data;
+    }
+    from(data: string): number {
+        return parseFloat(data);
+    }
+}

--- a/src/infrastructure/sql/models/produto.model.ts
+++ b/src/infrastructure/sql/models/produto.model.ts
@@ -9,6 +9,7 @@ import {
   JoinColumn,
 } from 'typeorm';
 import { CategoriaModel } from './categoria.model';
+import { ColumnNumericTransformer } from './ColumnNumericTransformer';
 
 @Entity({ name: 'produtos' })
 export class ProdutoModel {
@@ -21,7 +22,7 @@ export class ProdutoModel {
   @Column({ name: 'descricao', length: 255, nullable: true })
   descricao: string;
 
-  @Column({ type: 'money', name: 'valor_unitario', nullable: false })
+  @Column({ type: 'numeric', name: 'valor_unitario', nullable: false, transformer: new ColumnNumericTransformer(), })
   valorUnitario: number;
 
   @Column({ name: 'imagem_url', length: 2048, nullable: false })


### PR DESCRIPTION
Correção tipo de dado do campo `valorUnitario`

Antes da correção
<img width="197" alt="image" src="https://github.com/Grupo-G03-4SOAT-FIAP/rms-bff/assets/5115895/bcef57d4-c810-46e2-917e-df5844673bfb">

Depois da correção
<img width="248" alt="image" src="https://github.com/Grupo-G03-4SOAT-FIAP/rms-bff/assets/5115895/af10f346-aa4c-46b9-a6af-31bed022c35f">

Testes ok.
<img width="543" alt="image" src="https://github.com/Grupo-G03-4SOAT-FIAP/rms-bff/assets/5115895/8de5956d-d5fd-4662-bb37-ef879a6a5cf9">
